### PR TITLE
Clamp mobile detection to viewport width

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -6,14 +6,247 @@ import CenterPanel from './components/CenterPanel';
 import RightSidebar from './components/RightSidebar';
 import Timeline from './components/Timeline';
 
-const App: React.FC = () => {
+const MIN_PANEL_WIDTH = 220;
+const MAX_PANEL_WIDTH = 420;
+const MIN_CENTER_WIDTH = 480;
+
+type MobilePanelToggleProps = {
+  side: 'left' | 'right';
+  isOpen: boolean;
+  onToggle: () => void;
+};
+
+const MobilePanelToggle: React.FC<MobilePanelToggleProps> = ({ side, isOpen, onToggle }) => {
+  const isLeft = side === 'left';
+  const label = `${isOpen ? 'Hide' : 'Show'} ${isLeft ? 'assets' : 'properties'} panel`;
+  const rotateClass = isLeft ? (isOpen ? 'rotate-180' : '') : isOpen ? '' : 'rotate-180';
+  const edgeRounding = isLeft ? 'rounded-r-lg' : 'rounded-l-lg';
+  const offsetStyle: React.CSSProperties = isLeft
+    ? {
+        left: isOpen ? 'calc(min(18rem, 85vw) + 0.5rem)' : '0.75rem',
+      }
+    : {
+        right: isOpen ? 'calc(min(20rem, 85vw) + 0.5rem)' : '0.75rem',
+      };
+
   return (
-    <div className="flex flex-col h-screen bg-[#1e1e1e] text-gray-300 font-sans overflow-hidden">
-      <Header />
-      <div className="flex flex-1 min-h-0">
-        <LeftSidebar />
+    <button
+      type="button"
+      aria-label={label}
+      onClick={onToggle}
+      className={`fixed top-1/2 -translate-y-1/2 z-40 flex items-center justify-center w-9 h-16 bg-black/60 border border-white/10 text-white backdrop-blur ${edgeRounding} shadow-lg transition-colors hover:bg-black/70`}
+      style={offsetStyle}
+    >
+      <svg
+        className={`w-4 h-4 transition-transform duration-200 ${rotateClass}`}
+        viewBox="0 0 24 24"
+        fill="none"
+        stroke="currentColor"
+        strokeWidth="2"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M9 5l7 7-7 7" />
+      </svg>
+    </button>
+  );
+};
+
+const App: React.FC = () => {
+  const containerRef = React.useRef<HTMLDivElement>(null);
+  const [leftPanelWidth, setLeftPanelWidth] = React.useState(300);
+  const [rightPanelWidth, setRightPanelWidth] = React.useState(320);
+  const [draggingPanel, setDraggingPanel] = React.useState<'left' | 'right' | null>(null);
+  const [isMobile, setIsMobile] = React.useState(false);
+  const [leftOpen, setLeftOpen] = React.useState(true);
+  const [rightOpen, setRightOpen] = React.useState(true);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const node = containerRef.current;
+    const updateIsMobile = (width: number) => {
+      const next = width < 1024;
+      setIsMobile((prev) => (prev === next ? prev : next));
+    };
+
+    const fallbackResizeHandler = () => updateIsMobile(window.innerWidth);
+
+    if (node) {
+      const rectWidth = node.getBoundingClientRect().width || window.innerWidth;
+      updateIsMobile(Math.min(rectWidth, window.innerWidth));
+    } else {
+      updateIsMobile(window.innerWidth);
+    }
+    window.addEventListener('resize', fallbackResizeHandler);
+
+    let resizeObserver: ResizeObserver | null = null;
+    if (node && 'ResizeObserver' in window) {
+      resizeObserver = new ResizeObserver((entries) => {
+        for (const entry of entries) {
+          const width = entry.contentRect?.width ?? node.getBoundingClientRect().width;
+          updateIsMobile(Math.min(width, window.innerWidth));
+        }
+      });
+      resizeObserver.observe(node);
+    }
+
+    return () => {
+      window.removeEventListener('resize', fallbackResizeHandler);
+      resizeObserver?.disconnect();
+    };
+  }, []);
+
+  React.useEffect(() => {
+    if (isMobile) {
+      setLeftOpen(false);
+      setRightOpen(false);
+    } else {
+      setLeftOpen(true);
+      setRightOpen(true);
+    }
+  }, [isMobile]);
+
+  React.useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handlePointerMove = (event: PointerEvent) => {
+      if (!draggingPanel || isMobile) {
+        return;
+      }
+
+      if (draggingPanel === 'left') {
+        const rawWidth = event.clientX;
+        const maxAllowed = window.innerWidth - (rightOpen ? rightPanelWidth : 0) - MIN_CENTER_WIDTH;
+        const constrainedMax = Math.max(MIN_PANEL_WIDTH, maxAllowed);
+        const clamped = Math.min(
+          MAX_PANEL_WIDTH,
+          Math.max(MIN_PANEL_WIDTH, Math.min(rawWidth, constrainedMax)),
+        );
+        setLeftPanelWidth(clamped);
+      } else if (draggingPanel === 'right') {
+        const rawWidth = window.innerWidth - event.clientX;
+        const maxAllowed = window.innerWidth - (leftOpen ? leftPanelWidth : 0) - MIN_CENTER_WIDTH;
+        const constrainedMax = Math.max(MIN_PANEL_WIDTH, maxAllowed);
+        const clamped = Math.min(
+          MAX_PANEL_WIDTH,
+          Math.max(MIN_PANEL_WIDTH, Math.min(rawWidth, constrainedMax)),
+        );
+        setRightPanelWidth(clamped);
+      }
+    };
+
+    const stopDragging = () => {
+      setDraggingPanel(null);
+    };
+
+    window.addEventListener('pointermove', handlePointerMove);
+    window.addEventListener('pointerup', stopDragging);
+
+    return () => {
+      window.removeEventListener('pointermove', handlePointerMove);
+      window.removeEventListener('pointerup', stopDragging);
+    };
+  }, [draggingPanel, isMobile, leftOpen, leftPanelWidth, rightOpen, rightPanelWidth]);
+
+  const handleToggleLeft = React.useCallback(() => {
+    setLeftOpen((prev) => {
+      const next = !prev;
+      if (isMobile && next) {
+        setRightOpen(false);
+      }
+      return next;
+    });
+  }, [isMobile]);
+
+  const handleToggleRight = React.useCallback(() => {
+    setRightOpen((prev) => {
+      const next = !prev;
+      if (isMobile && next) {
+        setLeftOpen(false);
+      }
+      return next;
+    });
+  }, [isMobile]);
+
+  const startDragging = React.useCallback((panel: 'left' | 'right') => (event: React.PointerEvent) => {
+    if (isMobile) {
+      return;
+    }
+    event.preventDefault();
+    event.stopPropagation();
+    setDraggingPanel(panel);
+  }, [isMobile]);
+
+  const closePanels = React.useCallback(() => {
+    setLeftOpen(false);
+    setRightOpen(false);
+  }, []);
+
+  return (
+    <div ref={containerRef} className="flex flex-col h-screen bg-[#1e1e1e] text-gray-300 font-sans overflow-hidden">
+      <Header
+        isMobile={isMobile}
+        onToggleLeft={handleToggleLeft}
+        onToggleRight={handleToggleRight}
+        leftOpen={leftOpen}
+        rightOpen={rightOpen}
+      />
+      <div className="flex flex-1 min-h-0 relative">
+        {!isMobile && leftOpen && (
+          <div className="h-full flex-shrink-0" style={{ width: leftPanelWidth }}>
+            <LeftSidebar />
+          </div>
+        )}
+        {!isMobile && leftOpen && (
+          <div
+            className="w-1 cursor-col-resize flex-shrink-0 relative group"
+            onPointerDown={startDragging('left')}
+          >
+            <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-zinc-700 group-hover:bg-blue-400 transition-colors" />
+          </div>
+        )}
+
         <CenterPanel />
-        <RightSidebar />
+
+        {!isMobile && rightOpen && (
+          <div
+            className="w-1 cursor-col-resize flex-shrink-0 relative group"
+            onPointerDown={startDragging('right')}
+          >
+            <div className="absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-zinc-700 group-hover:bg-blue-400 transition-colors" />
+          </div>
+        )}
+        {!isMobile && rightOpen && (
+          <div className="h-full flex-shrink-0" style={{ width: rightPanelWidth }}>
+            <RightSidebar />
+          </div>
+        )}
+
+        {isMobile && leftOpen && (
+          <LeftSidebar isMobile onClose={() => setLeftOpen(false)} className="lg:hidden" />
+        )}
+        {isMobile && rightOpen && (
+          <RightSidebar isMobile onClose={() => setRightOpen(false)} className="lg:hidden" />
+        )}
+        {isMobile && (
+          <>
+            <MobilePanelToggle side="left" isOpen={leftOpen} onToggle={handleToggleLeft} />
+            <MobilePanelToggle side="right" isOpen={rightOpen} onToggle={handleToggleRight} />
+          </>
+        )}
+        {isMobile && (leftOpen || rightOpen) && (
+          <button
+            type="button"
+            aria-label="Close panels"
+            className="fixed inset-x-0 top-14 bottom-0 bg-black/40 z-30"
+            onClick={closePanels}
+          />
+        )}
       </div>
       <Timeline />
     </div>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -1,29 +1,62 @@
 
 import React from 'react';
-import { DeviceIcon, RefreshIcon, FullscreenIcon } from '../constants';
+import {
+  DeviceIcon,
+  RefreshIcon,
+  FullscreenIcon,
+  PanelsIcon,
+  AdjustmentsIcon,
+} from '../constants';
 
+type HeaderProps = {
+  isMobile: boolean;
+  onToggleLeft: () => void;
+  onToggleRight: () => void;
+  leftOpen: boolean;
+  rightOpen: boolean;
+};
 
-const Header: React.FC = () => {
+const Header: React.FC<HeaderProps> = ({ isMobile, onToggleLeft, onToggleRight, leftOpen, rightOpen }) => {
   return (
-    <header className="flex items-center justify-between h-14 px-4 bg-[#252526] border-b border-zinc-700 flex-shrink-0 z-10">
-      <div className="flex items-center space-x-2">
-        <div className="flex items-center bg-zinc-700 rounded-md p-0.5">
+    <header className="flex items-center justify-between h-14 px-4 bg-[#252526] border-b border-zinc-700 flex-shrink-0 z-40">
+      <div className="flex items-center space-x-3">
+        {isMobile && (
+          <div className="flex items-center space-x-2">
+            <button
+              type="button"
+              onClick={onToggleLeft}
+              aria-pressed={leftOpen}
+              className={`p-2 rounded-md border border-zinc-700 bg-zinc-800 text-gray-300 hover:text-white hover:border-blue-500 ${leftOpen ? 'border-blue-500 text-white' : ''}`}
+            >
+              <PanelsIcon className="w-5 h-5" />
+            </button>
+            <button
+              type="button"
+              onClick={onToggleRight}
+              aria-pressed={rightOpen}
+              className={`p-2 rounded-md border border-zinc-700 bg-zinc-800 text-gray-300 hover:text-white hover:border-blue-500 ${rightOpen ? 'border-blue-500 text-white' : ''}`}
+            >
+              <AdjustmentsIcon className="w-5 h-5" />
+            </button>
+          </div>
+        )}
+        <div className="hidden sm:flex items-center bg-zinc-700 rounded-md p-0.5">
           <button className="px-3 py-1 text-sm bg-zinc-800 rounded-sm">Preview</button>
           <button className="px-3 py-1 text-sm text-gray-400">Code</button>
         </div>
-        <button className="flex items-center space-x-2 px-3 py-1 text-sm text-gray-400 hover:text-white">
+        <button className="hidden md:flex items-center space-x-2 px-3 py-1 text-sm text-gray-400 hover:text-white">
           <FullscreenIcon className="w-4 h-4" />
           <span>Full screen</span>
         </button>
       </div>
-      <div className="flex items-center space-x-4">
-        <button className="p-2 text-gray-400 hover:text-white">
+      <div className="flex items-center space-x-3">
+        <button className="p-2 text-gray-400 hover:text-white hidden md:inline-flex">
             <DeviceIcon className="w-5 h-5" />
         </button>
-        <button className="p-2 text-gray-400 hover:text-white">
+        <button className="p-2 text-gray-400 hover:text-white hidden md:inline-flex">
             <RefreshIcon className="w-5 h-5" />
         </button>
-        <button className="px-5 py-1.5 text-sm font-semibold text-white bg-zinc-700 rounded-md hover:bg-zinc-600 transition-colors">
+        <button className="px-4 py-1.5 text-sm font-semibold text-white bg-zinc-700 rounded-md hover:bg-zinc-600 transition-colors hidden sm:inline-flex">
           Save
         </button>
         <img

--- a/components/LeftSidebar.tsx
+++ b/components/LeftSidebar.tsx
@@ -3,6 +3,13 @@ import React from 'react';
 import { ASSET_CATEGORIES, TEMPLATE_FILTERS, MOCK_TEMPLATES } from '../constants';
 import type { Template } from '../types';
 
+type LeftSidebarProps = {
+  isMobile?: boolean;
+  onClose?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
 const AssetGrid: React.FC<{ templates: Template[] }> = ({ templates }) => (
   <div className="grid grid-cols-2 gap-3 p-4">
     {templates.map((template) => (
@@ -14,37 +21,53 @@ const AssetGrid: React.FC<{ templates: Template[] }> = ({ templates }) => (
   </div>
 );
 
-const LeftSidebar: React.FC = () => {
+const LeftSidebar: React.FC<LeftSidebarProps> = ({ isMobile = false, onClose, className = '', style }) => {
+  const containerClasses = `${isMobile ? 'fixed top-14 bottom-0 left-0 z-40 w-72 max-w-[85vw] shadow-2xl lg:hidden' : 'h-full flex-shrink-0'} bg-[#252526] border-r border-zinc-700 flex flex-col ${className}`.trim();
+
   return (
-    <aside className="w-[300px] bg-[#252526] flex-shrink-0 border-r border-zinc-700 flex flex-col">
-       <div className="p-3 border-b border-zinc-700 flex flex-col space-y-3">
-         <div className="flex items-center space-x-2">
-            {ASSET_CATEGORIES.map(cat => (
-                <button key={cat.name} className="flex flex-col items-center p-2 rounded-md hover:bg-zinc-700 space-y-1 w-16">
-                    <cat.icon className="w-6 h-6"/>
-                    <span className="text-xs">{cat.name}</span>
-                </button>
-            ))}
-         </div>
-          <div className="relative">
-            <input
-              type="text"
-              placeholder="Search templates"
-              className="w-full py-2 pl-10 pr-4 text-sm bg-zinc-800 border border-zinc-700 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
-            />
-            <div className="absolute inset-y-0 left-0 flex items-center pl-3">
-              <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
-            </div>
-          </div>
-          <div className="flex space-x-2 overflow-x-auto scrollbar-hide">
-            {TEMPLATE_FILTERS.map(filter => (
-               <button key={filter} className="px-3 py-1 text-sm bg-zinc-700 rounded-md hover:bg-zinc-600 whitespace-nowrap">{filter}</button>
-            ))}
+    <aside className={containerClasses} style={style}>
+      <div className="p-3 border-b border-zinc-700 flex flex-col space-y-3">
+        <div className="flex items-center justify-between">
+          <span className="text-sm font-semibold uppercase tracking-wide text-gray-200">Assets</span>
+          {isMobile && (
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-2 py-1 text-xs font-medium text-gray-300 bg-zinc-800 rounded hover:bg-zinc-700"
+            >
+              Close
+            </button>
+          )}
+        </div>
+        <div className="flex items-center space-x-2 overflow-x-auto scrollbar-hide">
+          {ASSET_CATEGORIES.map((cat) => (
+            <button key={cat.name} className="flex flex-col items-center p-2 rounded-md hover:bg-zinc-700 space-y-1 w-16 flex-shrink-0">
+              <cat.icon className="w-6 h-6" />
+              <span className="text-xs">{cat.name}</span>
+            </button>
+          ))}
+        </div>
+        <div className="relative">
+          <input
+            type="text"
+            placeholder="Search templates"
+            className="w-full py-2 pl-10 pr-4 text-sm bg-zinc-800 border border-zinc-700 rounded-md focus:outline-none focus:ring-1 focus:ring-blue-500"
+          />
+          <div className="absolute inset-y-0 left-0 flex items-center pl-3">
+            <svg className="w-4 h-4 text-gray-400" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z" /></svg>
           </div>
         </div>
-        <div className="flex-1 overflow-y-auto">
-          <AssetGrid templates={MOCK_TEMPLATES} />
+        <div className="flex space-x-2 overflow-x-auto scrollbar-hide">
+          {TEMPLATE_FILTERS.map((filter) => (
+            <button key={filter} className="px-3 py-1 text-sm bg-zinc-700 rounded-md hover:bg-zinc-600 whitespace-nowrap flex-shrink-0">
+              {filter}
+            </button>
+          ))}
         </div>
+      </div>
+      <div className="flex-1 overflow-y-auto">
+        <AssetGrid templates={MOCK_TEMPLATES} />
+      </div>
     </aside>
   );
 };

--- a/components/RightSidebar.tsx
+++ b/components/RightSidebar.tsx
@@ -2,6 +2,13 @@
 import React, { useState } from 'react';
 import { PROPERTIES_TABS, PropertyGroup } from '../constants';
 
+type RightSidebarProps = {
+  isMobile?: boolean;
+  onClose?: () => void;
+  className?: string;
+  style?: React.CSSProperties;
+};
+
 const Accordion: React.FC<{ title: string; children: React.ReactNode; defaultOpen?: boolean }> = ({ title, children, defaultOpen = false }) => {
   const [isOpen, setIsOpen] = useState(defaultOpen);
   return (
@@ -26,9 +33,9 @@ const PropertyInput: React.FC<{ label: string; value: string; isLinked?: boolean
   </div>
 );
 
-const RightSidebar: React.FC = () => {
+const RightSidebar: React.FC<RightSidebarProps> = ({ isMobile = false, onClose, className = '', style }) => {
   const [activeTab, setActiveTab] = useState('Properties');
-  
+
   const renderPanelContent = () => {
     switch (activeTab) {
       case 'Properties':
@@ -56,18 +63,31 @@ const RightSidebar: React.FC = () => {
     }
   };
 
+  const containerClasses = `${isMobile ? 'fixed top-14 bottom-0 right-0 z-40 w-80 max-w-[85vw] shadow-2xl lg:hidden' : 'h-full flex-shrink-0'} bg-[#252526] border-l border-zinc-700 flex flex-col ${className}`.trim();
+
   return (
-    <aside className="w-[320px] bg-[#252526] flex-shrink-0 border-l border-zinc-700 flex flex-col">
-      <div className="flex border-b border-zinc-700">
-        {PROPERTIES_TABS.map(tab => (
-          <button 
-            key={tab} 
-            onClick={() => setActiveTab(tab)}
-            className={`px-4 py-2 text-sm font-medium flex-1 ${activeTab === tab ? 'text-white border-b-2 border-blue-500' : 'text-gray-400 hover:bg-zinc-700/50'}`}
+    <aside className={containerClasses} style={style}>
+      <div className="flex items-center border-b border-zinc-700">
+        <div className="flex flex-1">
+          {PROPERTIES_TABS.map((tab) => (
+            <button
+              key={tab}
+              onClick={() => setActiveTab(tab)}
+              className={`px-4 py-2 text-sm font-medium flex-1 ${activeTab === tab ? 'text-white border-b-2 border-blue-500' : 'text-gray-400 hover:bg-zinc-700/50'}`}
+            >
+              {tab}
+            </button>
+          ))}
+        </div>
+        {isMobile && (
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 text-xs font-medium text-gray-300 bg-zinc-800 rounded-l hover:bg-zinc-700"
           >
-            {tab}
+            Close
           </button>
-        ))}
+        )}
       </div>
       <div className="flex-1 overflow-y-auto">
         {renderPanelContent()}

--- a/constants.tsx
+++ b/constants.tsx
@@ -11,6 +11,12 @@ export const RefreshIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
 export const FullscreenIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
     <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 8V4h4M20 8V4h-4M4 16v4h4M20 16v4h-4" /></svg>
 );
+export const PanelsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M3 5h7a2 2 0 012 2v12H5a2 2 0 01-2-2V5zm11 0h5a2 2 0 012 2v5h-7V5zm0 9h7v5a2 2 0 01-2 2h-5v-7z" /></svg>
+);
+export const AdjustmentsIcon: React.FC<React.SVGProps<SVGSVGElement>> = (props) => (
+    <svg {...props} fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M4 6h4M10 6h10M4 12h6M12 12h8M4 18h2M8 18h12M8 4v4M14 10v4M6 16v4" /></svg>
+);
 
 
 // Icons for Left Sidebar


### PR DESCRIPTION
## Summary
- clamp the resize observer width to the viewport so the container can't force desktop mode on narrow viewports
- keep the initial mobile detection consistent with viewport width to restore responsive panel toggling

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68df672414288325be7508fac6836199